### PR TITLE
socket.gethostbyname(socket.gethostname()) doesn't work on every environment

### DIFF
--- a/paypalx/__init__.py
+++ b/paypalx/__init__.py
@@ -90,7 +90,10 @@ class AdaptiveAPI(object):
             print endpoint
         
         def device_ip():
-            return socket.gethostbyname(socket.gethostname())
+            try:
+                return socket.gethostbyname(socket.gethostname())
+            except:
+                return '127.0.0.1'
         
         headers = {
             'X-PAYPAL-SECURITY-USERID': self.username,


### PR DESCRIPTION
On the _request method there's an inner function like:

```
        def device_ip():
            return socket.gethostbyname(socket.gethostname())
```

This will throw an error if it is ran inside Travis CI:
"socket.gaierror: [Errno -2] Name or service not known"
See https://travis-ci.org/freedomsponsors/www.freedomsponsors.org/builds/6827236

Maybe there are other environments where it might fail too.

I was able to fix my unit test by using the code with the attached PR
Cheers
